### PR TITLE
Fix V3041, V3064 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/Advanced.Algorithms/DynamicProgramming/Maximizing/KnackSackProblems.cs
+++ b/Advanced.Algorithms/DynamicProgramming/Maximizing/KnackSackProblems.cs
@@ -60,7 +60,7 @@ namespace Advanced.Algorithms.DynamicProgramming
             //O(n)
             for (int i = 0; i < weights.Length; i++)
             {
-                ratios[i] = values[i] / weights[i];
+                ratios[i] = (double)values[i] / weights[i];
             }
             //(o(nlog(n)
             //quick sort by desc weights

--- a/Advanced.Algorithms/Sorting/BucketSort.cs
+++ b/Advanced.Algorithms/Sorting/BucketSort.cs
@@ -28,14 +28,17 @@ namespace Advanced.Algorithms.Sorting
             int i;
             for (i = 0; i < array.Length; i++)
             {
-                var bucketIndex = array[i] / bucketSize;
-
-                if(!buckets.ContainsKey(bucketIndex))
+                if (bucketSize != 0)
                 {
-                    buckets.Add(bucketIndex, new List<int>());
-                }
+                    var bucketIndex = array[i] / bucketSize;
 
-                buckets[bucketIndex].Add(array[i]);
+                    if (!buckets.ContainsKey(bucketIndex))
+                    {
+                        buckets.Add(bucketIndex, new List<int>());
+                    }
+
+                    buckets[bucketIndex].Add(array[i]);
+                }
             }
 
             i = 0;


### PR DESCRIPTION
Hello. I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

**About your warnings:** [V3041](https://www.viva64.com/en/w/V3041/), [V3064](https://www.viva64.com/en/w/V3064/).

### Warnings with High priority:

V3041 The expression was implicitly cast from 'int' type to 'double' type. Consider utilizing an explicit type cast to avoid the loss of a fractional part. An example: double A = (double)(X) / Y;. KnackSackProblems.cs 63

### Warnings with Low priority:

V3064 Potential division by zero. Consider inspecting denominator 'bucketSize'. BucketSort.cs 31