### PR TITLE
Fixes BpTree's IEnumerable Interface. 

### DIFF
--- a/Advanced.Algorithms.Tests/DataStructures/Tree/B+Tree_Tests.cs
+++ b/Advanced.Algorithms.Tests/DataStructures/Tree/B+Tree_Tests.cs
@@ -194,5 +194,12 @@ namespace Advanced.Algorithms.Tests.DataStructures
             Assert.IsTrue(tree.Count == 0);
 
         }
+
+        [TestMethod]
+        public void BPTree_Empty_Enumerator_Test()
+        {
+            var tree = new BpTree<int>(10);
+            Assert.IsFalse(tree.GetEnumerator().MoveNext());
+        }
     }
 }

--- a/Advanced.Algorithms/DataStructures/Tree/B+Tree.cs
+++ b/Advanced.Algorithms/DataStructures/Tree/B+Tree.cs
@@ -1031,6 +1031,11 @@ namespace Advanced.Algorithms.DataStructures
 
         public bool MoveNext()
         {
+            if (current == null)
+            {
+                return false;
+            }
+
             if (i + 1 < current.KeyCount)
             {
                 i++;


### PR DESCRIPTION
null reference exception when using empty BpTree enumerator.