### PR TITLE
moved Combination results to iterator to avoid memory overload

### DIFF
--- a/src/Advanced.Algorithms/Combinatorics/Combination.cs
+++ b/src/Advanced.Algorithms/Combinatorics/Combination.cs
@@ -7,23 +7,16 @@ namespace Advanced.Algorithms.Combinatorics
     /// </summary>
     public class Combination
     {
-        public static List<List<T>> Find<T>(List<T> input, int r, bool withRepetition)
+        public static IEnumerable<T[]> Find<T>(List<T> input, int r, bool withRepetition)
         {
-            var result = new List<List<T>>();
-
-            recurse(input, r, withRepetition, 0, new List<T>(), new HashSet<int>(), result);
-
-            return result;
+            return recurse(input, r, withRepetition, 0, new List<T>(), new HashSet<int>());
         }
 
-        private static void recurse<T>(List<T> input, int r, bool withRepetition,
-            int k, List<T> prefix, HashSet<int> prefixIndices,
-            List<List<T>> result)
+        private static IEnumerable<T[]> recurse<T>(List<T> input, int r, bool withRepetition,int k, List<T> prefix, HashSet<int> prefixIndices)
         {
             if (prefix.Count == r)
             {
-                result.Add(new List<T>(prefix));
-                return;
+                yield return prefix.ToArray();
             }
 
             for (int j = k; j < input.Count; j++)
@@ -36,12 +29,14 @@ namespace Advanced.Algorithms.Combinatorics
                 prefix.Add(input[j]);
                 prefixIndices.Add(j);
 
-                recurse(input, r, withRepetition, j, prefix, prefixIndices, result);
+                foreach (var item in recurse(input, r, withRepetition, j, prefix, prefixIndices))
+                {
+                    yield return item;
+                }
 
                 prefix.RemoveAt(prefix.Count - 1);
                 prefixIndices.Remove(j);
             }
         }
-
     }
 }

--- a/src/Advanced.Algorithms/Combinatorics/Combination.cs
+++ b/src/Advanced.Algorithms/Combinatorics/Combination.cs
@@ -12,7 +12,7 @@ namespace Advanced.Algorithms.Combinatorics
             return recurse(input, r, withRepetition, 0, new List<T>(), new HashSet<int>());
         }
 
-        private static IEnumerable<T[]> recurse<T>(List<T> input, int r, bool withRepetition,int k, List<T> prefix, HashSet<int> prefixIndices)
+        private static IEnumerable<T[]> recurse<T>(List<T> input, int r, bool withRepetition, int k, List<T> prefix, HashSet<int> prefixIndices)
         {
             if (prefix.Count == r)
             {

--- a/tests/Advanced.Algorithms.Tests/Combinatorics/Combination_Tests.cs
+++ b/tests/Advanced.Algorithms.Tests/Combinatorics/Combination_Tests.cs
@@ -20,15 +20,15 @@ namespace Advanced.Algorithms.Tests.Combinatorics
         public void Combination_Without_Repetitions_Smoke_Test()
         {
             var input = "".ToCharArray().ToList();
-            var combinations = Combination.Find<char>(input, 2, false);
+            var combinations = Combination.Find<char>(input, 2, false).ToList();
             Assert.AreEqual(combination(input.Count, 2), combinations.Count);
 
             input = "cookie".ToCharArray().ToList();
-            combinations = Combination.Find<char>(input, 3, false);
+            combinations = Combination.Find<char>(input, 3, false).ToList();
             Assert.AreEqual(combination(input.Count, 3), combinations.Count);
 
             input = "monster".ToCharArray().ToList();
-            combinations = Combination.Find<char>(input, 4, false);
+            combinations = Combination.Find<char>(input, 4, false).ToList();
             Assert.AreEqual(combination(input.Count, 4), combinations.Count);
         }
 
@@ -37,15 +37,15 @@ namespace Advanced.Algorithms.Tests.Combinatorics
         public void Combination_With_Repetitions_Smoke_Test()
         {
             var input = "".ToCharArray().ToList();
-            var combinations = Combination.Find<char>(input, 3, true);
+            var combinations = Combination.Find<char>(input, 3, true).ToList();
             Assert.AreEqual(0, combinations.Count);
 
             input = "pen".ToCharArray().ToList();
-            combinations = Combination.Find<char>(input, 2, true);
+            combinations = Combination.Find<char>(input, 2, true).ToList();
             Assert.AreEqual(combination(input.Count + 2 - 1, 2), combinations.Count);
 
             input = "scan".ToCharArray().ToList();
-            combinations = Combination.Find<char>(input, 3, true);
+            combinations = Combination.Find<char>(input, 3, true).ToList();
             Assert.AreEqual(combination(input.Count + 3 - 1, 3), combinations.Count);
         }
 


### PR DESCRIPTION
- [x] This is not a new algorithm. See readme.
Doneness:
- [ ] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against master branch 
